### PR TITLE
fix unrequired duplication of connection

### DIFF
--- a/lib/directive_record/query/sql.rb
+++ b/lib/directive_record/query/sql.rb
@@ -74,7 +74,8 @@ SQL
       end
 
       def to_options(args)
-        options = args.extract_options!.deep_dup
+        args_without_connection = [args[0].except(:connection)]
+        options = args_without_connection.extract_options!.deep_dup
         options.reverse_merge! :select => (args.empty? ? "*" : args)
 
         [:select, :where, :group_by, :order_by].each do |key|

--- a/lib/directive_record/query/sql.rb
+++ b/lib/directive_record/query/sql.rb
@@ -74,8 +74,7 @@ SQL
       end
 
       def to_options(args)
-        args_without_connection = [args[0].except(:connection)]
-        options = args_without_connection.extract_options!.deep_dup
+        options = args.extract_options!.except(:connection).deep_dup
         options.reverse_merge! :select => (args.empty? ? "*" : args)
 
         [:select, :where, :group_by, :order_by].each do |key|


### PR DESCRIPTION
Hi @archan937,

Connection object is being deep copied inside this function.
As its not needed, it isn't used in scope, could you accept pull request?
